### PR TITLE
hotfix: move window into useEffect

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -78,7 +78,9 @@ export default function Header(props) {
     [classes.onScroll]: scrollY > 0,
   })
   // header scroll control
-  window.onscroll = logScroll
+  useEffect(() => {
+    window.onscroll = logScroll
+  }, [])
 
   function logScroll(e) {
     const { scrollY } = e.currentTarget


### PR DESCRIPTION
window is not defined in sever side rendering. It is only defined once component is mounted.